### PR TITLE
Fix parsing scientific numbers and support implicit 'lineto' commands.

### DIFF
--- a/Tests/CGPathTests.swift
+++ b/Tests/CGPathTests.swift
@@ -199,6 +199,26 @@ class CGPathTests: XCTestCase {
         cgPath.closeSubpath()
         XCTAssertEqual(.from(svgPath: svgPath), cgPath)
     }
+
+    func testScientificNotationNumbers() throws {
+        let svgPath = try SVGPath(string: "M150 0 L75 200e+0 225e-0 200 Z")
+        let cgPath = CGMutablePath()
+        cgPath.move(to: CGPoint(x: 150, y: 0))
+        cgPath.addLine(to: CGPoint(x: 75, y: -200))
+        cgPath.addLine(to: CGPoint(x: 225, y: -200))
+        cgPath.closeSubpath()
+        XCTAssertEqual(.from(svgPath: svgPath), cgPath)
+    }
+
+    func testImplicitLines() throws {
+        let svgPath = try SVGPath(string: "M150 0 75 200 225 200 Z")
+        let cgPath = CGMutablePath()
+        cgPath.move(to: CGPoint(x: 150, y: 0))
+        cgPath.addLine(to: CGPoint(x: 75, y: -200))
+        cgPath.addLine(to: CGPoint(x: 225, y: -200))
+        cgPath.closeSubpath()
+        XCTAssertEqual(.from(svgPath: svgPath), cgPath)
+    }
 }
 
 #endif

--- a/Tests/SVGPathTests.swift
+++ b/Tests/SVGPathTests.swift
@@ -92,4 +92,26 @@ class SVGPathTests: XCTestCase {
         ])
         XCTAssertEqual(svgPath, expected)
     }
+
+    func testScientificNotationNumbers() throws {
+        let svgPath = try SVGPath(string: "M150 0 L75 200e+0 225e-0 200 Z")
+        let expected = SVGPath(commands: [
+            .moveTo(.init(x: 150, y: 0)),
+            .lineTo(.init(x: 75, y: -200)),
+            .lineTo(.init(x: 225, y: -200)),
+            .end,
+        ])
+        XCTAssertEqual(svgPath, expected)
+    }
+
+    func testImplicitLines() throws {
+        let svgPath = try SVGPath(string: "M150 0 75 200 225 200 Z")
+        let expected = SVGPath(commands: [
+            .moveTo(.init(x: 150, y: 0)),
+            .lineTo(.init(x: 75, y: -200)),
+            .lineTo(.init(x: 225, y: -200)),
+            .end,
+        ])
+        XCTAssertEqual(svgPath, expected)
+    }
 }


### PR DESCRIPTION
Accordance to [moveto](https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands) command:
`If a moveto is followed by multiple pairs of coordinates, the subsequent pairs are treated as implicit lineto commands`